### PR TITLE
Correct Screw Size

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ BOM
 ---
 
 - 3mm acryl
-- 4x M3 screws
-- 4x M3 screw nuts
+- 4x M2.5 10mm screws
+- 4x M2.5 screw nuts
 
 Visicut color-mapping
 ---------------------


### PR DESCRIPTION
According to the [board specs](http://www.raspberrypi.org/raspberry-pi-rev2-template-with-mounting-holes/) the holes are drilled 2.75mm to accept a M2.5 screw, not an M3 screw as per the BOM.

Given 3mm acrylic base, 3mm acrylic standoffs, ~1.6mm PCB, plus a nut, 10mm screw length is appropriate.